### PR TITLE
CORE-8622 Stop building obsolete tool-registration Docker image.

### DIFF
--- a/service.properties
+++ b/service.properties
@@ -1,1 +1,2 @@
+repo = permissions
 dockerUser = discoenv


### PR DESCRIPTION
The `tool-registration` utility is no longer required since it has already run in production.
This is almost a revert of the `Jenkinsfile` and `service.properties` files to version `2.10.0`, except updates to the Jenkinsfile beyond the app and tool registration utilities should be retained.