### PR TITLE
Add a db.schema configuration and use it to set the search_path

### DIFF
--- a/restapi/impl/permissions/by_subject.go
+++ b/restapi/impl/permissions/by_subject.go
@@ -33,7 +33,7 @@ func bySubjectBadRequest(reason string) middleware.Responder {
 
 // BuildBySubjectHandler builds the request handler for the permissions by subject endpoint
 func BuildBySubjectHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.BySubjectParams) middleware.Responder {
 
 	// Return the handler function.
@@ -45,6 +45,12 @@ func BuildBySubjectHandler(
 
 		// Create a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return bySubjectInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return bySubjectInternalServerError(err.Error())

--- a/restapi/impl/permissions/by_subject_and_resource.go
+++ b/restapi/impl/permissions/by_subject_and_resource.go
@@ -33,7 +33,7 @@ func bySubjectAndResourceBadRequest(reason string) middleware.Responder {
 
 // BuildBySubjectAndResourceHandler builds the request handler for the permissions by subject and resource endpoint.
 func BuildBySubjectAndResourceHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.BySubjectAndResourceParams) middleware.Responder {
 
 	// Return the handler function.
@@ -47,6 +47,12 @@ func BuildBySubjectAndResourceHandler(
 
 		// Start a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return bySubjectAndResourceInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return bySubjectAndResourceInternalServerError(err.Error())

--- a/restapi/impl/permissions/by_subject_and_resource_type.go
+++ b/restapi/impl/permissions/by_subject_and_resource_type.go
@@ -34,7 +34,7 @@ func bySubjectAndResourceTypeBadRequest(reason string) middleware.Responder {
 // BuildBySubjectAndResourceTypeHandler builds the request handler for the permissions by subject and resource type
 // endpoint.
 func BuildBySubjectAndResourceTypeHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.BySubjectAndResourceTypeParams) middleware.Responder {
 
 	// Return the handler function.
@@ -47,6 +47,12 @@ func BuildBySubjectAndResourceTypeHandler(
 
 		// Create a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return bySubjectAndResourceTypeInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return bySubjectAndResourceTypeInternalServerError(err.Error())

--- a/restapi/impl/permissions/by_subject_and_resource_type_abbreviated.go
+++ b/restapi/impl/permissions/by_subject_and_resource_type_abbreviated.go
@@ -31,7 +31,7 @@ func bySubjectAndResourceTypeAbbreviatedBadRequest(reason string) middleware.Res
 }
 
 func BuildBySubjectAndResourceTypeAbbreviatedHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.BySubjectAndResourceTypeAbbreviatedParams) middleware.Responder {
 
 	// Return the handler function.
@@ -49,6 +49,12 @@ func BuildBySubjectAndResourceTypeAbbreviatedHandler(
 			return bySubjectAndResourceTypeAbbreviatedInternalServerError(err.Error())
 		}
 		defer tx.Rollback()
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
+		if err != nil {
+			logger.Log.Error(err)
+			return bySubjectAndResourceTypeAbbreviatedInternalServerError(err.Error())
+		}
 
 		// Verify that the subject type is correct.
 		subject, err := permsdb.GetSubjectByExternalID(tx, models.ExternalSubjectID(subjectID))

--- a/restapi/impl/permissions/grant_permission.go
+++ b/restapi/impl/permissions/grant_permission.go
@@ -2,6 +2,7 @@ package permissions
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/cyverse-de/permissions/clients/grouper"
 	"github.com/cyverse-de/permissions/logger"
@@ -26,7 +27,7 @@ func grantPermissionBadRequest(reason string) middleware.Responder {
 
 // BuildGrantPermissionHandler builds the request handler for the grant permissions endpoint.
 func BuildGrantPermissionHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.GrantPermissionParams) middleware.Responder {
 
 	erf := &ErrorResponseFns{
@@ -40,6 +41,12 @@ func BuildGrantPermissionHandler(
 
 		// Create a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return grantPermissionInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return grantPermissionInternalServerError(err.Error())

--- a/restapi/impl/permissions/list_resource_permissions.go
+++ b/restapi/impl/permissions/list_resource_permissions.go
@@ -2,6 +2,7 @@ package permissions
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/cyverse-de/permissions/clients/grouper"
 	"github.com/cyverse-de/permissions/logger"
@@ -26,7 +27,7 @@ func listResourcePermissionsInternalServerError(reason string) middleware.Respon
 
 // BuildListResourcePermissionsHandler builds the request handler for the list resource permissions endpoint.
 func BuildListResourcePermissionsHandler(
-	db *sql.DB, grouperClient grouper.Grouper,
+	db *sql.DB, grouperClient grouper.Grouper, schema string,
 ) func(permissions.ListResourcePermissionsParams) middleware.Responder {
 
 	// Return the handler function.
@@ -36,6 +37,12 @@ func BuildListResourcePermissionsHandler(
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return listResourcePermissionsInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return listResourcePermissionsInternalServerError(err.Error())

--- a/restapi/impl/permissions/revoke_permission.go
+++ b/restapi/impl/permissions/revoke_permission.go
@@ -25,13 +25,19 @@ func revokePermissionNotFound(reason string) middleware.Responder {
 }
 
 // BuildRevokePermissionHandler builds the request handler for the revoke permission endpoint.
-func BuildRevokePermissionHandler(db *sql.DB) func(permissions.RevokePermissionParams) middleware.Responder {
+func BuildRevokePermissionHandler(db *sql.DB, schema string) func(permissions.RevokePermissionParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params permissions.RevokePermissionParams) middleware.Responder {
 
 		// Create a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return revokePermissionInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return revokePermissionInternalServerError(err.Error())

--- a/restapi/impl/resources/delete_resource_by_name.go
+++ b/restapi/impl/resources/delete_resource_by_name.go
@@ -29,13 +29,19 @@ func deleteResourceByNameNotFound(reason string) middleware.Responder {
 }
 
 // BuildDeleteResourceByNameHandler builds the request handler for the delete resource by name endpoint.
-func BuildDeleteResourceByNameHandler(db *sql.DB) func(resources.DeleteResourceByNameParams) middleware.Responder {
+func BuildDeleteResourceByNameHandler(db *sql.DB, schema string) func(resources.DeleteResourceByNameParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params resources.DeleteResourceByNameParams) middleware.Responder {
 
 		// Start a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return deleteResourceByNameInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return deleteResourceByNameInternalServerError(err.Error())

--- a/restapi/impl/resourcetypes/add_resource_types.go
+++ b/restapi/impl/resourcetypes/add_resource_types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BuildResourceTypesPostHandler builds the request handler for the add resource types endpoint.
-func BuildResourceTypesPostHandler(db *sql.DB) func(resource_types.PostResourceTypesParams) middleware.Responder {
+func BuildResourceTypesPostHandler(db *sql.DB, schema string) func(resource_types.PostResourceTypesParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params resource_types.PostResourceTypesParams) middleware.Responder {
@@ -19,6 +19,14 @@ func BuildResourceTypesPostHandler(db *sql.DB) func(resource_types.PostResourceT
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			reason := err.Error()
+			return resource_types.NewPostResourceTypesInternalServerError().WithPayload(
+				&models.ErrorOut{Reason: &reason},
+			)
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			reason := err.Error()
 			return resource_types.NewPostResourceTypesInternalServerError().WithPayload(

--- a/restapi/impl/resourcetypes/delete_resource_type_by_name.go
+++ b/restapi/impl/resourcetypes/delete_resource_type_by_name.go
@@ -36,7 +36,7 @@ func deleteResourceTypeByNameNotFound(reason string) middleware.Responder {
 
 // BuildDeleteResourceTypeByNameHandler builds the request handler for the resource type by name endpoint.
 func BuildDeleteResourceTypeByNameHandler(
-	db *sql.DB,
+	db *sql.DB, schema string,
 ) func(resource_types.DeleteResourceTypeByNameParams) middleware.Responder {
 
 	// Return the handler function.
@@ -44,6 +44,12 @@ func BuildDeleteResourceTypeByNameHandler(
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return deleteResourceTypeByNameInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return deleteResourceTypeByNameInternalServerError(err.Error())

--- a/restapi/impl/resourcetypes/delete_resource_types.go
+++ b/restapi/impl/resourcetypes/delete_resource_types.go
@@ -12,7 +12,7 @@ import (
 
 // BuildResourceTypesIDDeleteHandler builds the request handler for the resource type deletion endpoint.
 func BuildResourceTypesIDDeleteHandler(
-	db *sql.DB,
+	db *sql.DB, schema string,
 ) func(resource_types.DeleteResourceTypesIDParams) middleware.Responder {
 
 	// Return the handler function.
@@ -20,6 +20,14 @@ func BuildResourceTypesIDDeleteHandler(
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			reason := err.Error()
+			return resource_types.NewDeleteResourceTypesIDInternalServerError().WithPayload(
+				&models.ErrorOut{Reason: &reason},
+			)
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			reason := err.Error()
 			return resource_types.NewDeleteResourceTypesIDInternalServerError().WithPayload(

--- a/restapi/impl/resourcetypes/update_resource_types.go
+++ b/restapi/impl/resourcetypes/update_resource_types.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BuildResourceTypesIDPutHandler builds the request handler for the update resource type endpoint.
-func BuildResourceTypesIDPutHandler(db *sql.DB) func(resource_types.PutResourceTypesIDParams) middleware.Responder {
+func BuildResourceTypesIDPutHandler(db *sql.DB, schema string) func(resource_types.PutResourceTypesIDParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params resource_types.PutResourceTypesIDParams) middleware.Responder {
@@ -19,6 +19,14 @@ func BuildResourceTypesIDPutHandler(db *sql.DB) func(resource_types.PutResourceT
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			reason := err.Error()
+			return resource_types.NewPutResourceTypesIDInternalServerError().WithPayload(
+				&models.ErrorOut{Reason: &reason},
+			)
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			reason := err.Error()
 			return resource_types.NewPutResourceTypesIDInternalServerError().WithPayload(

--- a/restapi/impl/subjects/delete_subject.go
+++ b/restapi/impl/subjects/delete_subject.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BuildDeleteSubjectHandler builds the request handler for the delete subject endpoint.
-func BuildDeleteSubjectHandler(db *sql.DB) func(subjects.DeleteSubjectParams) middleware.Responder {
+func BuildDeleteSubjectHandler(db *sql.DB, schema string) func(subjects.DeleteSubjectParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params subjects.DeleteSubjectParams) middleware.Responder {
@@ -21,6 +21,15 @@ func BuildDeleteSubjectHandler(db *sql.DB) func(subjects.DeleteSubjectParams) mi
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			reason := err.Error()
+			return subjects.NewDeleteSubjectInternalServerError().WithPayload(
+				&models.ErrorOut{Reason: &reason},
+			)
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			reason := err.Error()

--- a/restapi/impl/subjects/delete_subject_by_external_id.go
+++ b/restapi/impl/subjects/delete_subject_by_external_id.go
@@ -30,7 +30,7 @@ func deleteSubjectByExternalIDOk() middleware.Responder {
 
 // BuildDeleteSubjectByExternalIDHandler builds the request handler for the delete subject by external ID endpoint.
 func BuildDeleteSubjectByExternalIDHandler(
-	db *sql.DB,
+	db *sql.DB, schema string,
 ) func(subjects.DeleteSubjectByExternalIDParams) middleware.Responder {
 
 	// Return the handler function.
@@ -40,6 +40,12 @@ func BuildDeleteSubjectByExternalIDHandler(
 
 		// Start a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return deleteSubjectByExternalIDInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return deleteSubjectByExternalIDInternalServerError(err.Error())

--- a/restapi/impl/subjects/list_subjects.go
+++ b/restapi/impl/subjects/list_subjects.go
@@ -2,6 +2,7 @@ package subjects
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/cyverse-de/permissions/logger"
 	"github.com/cyverse-de/permissions/models"
@@ -18,13 +19,19 @@ func listSubjectsInternalServerError(reason string) middleware.Responder {
 }
 
 // BuildListSubjectsHandler builds the request handler for the list subjects endpoint.
-func BuildListSubjectsHandler(db *sql.DB) func(subjects.ListSubjectsParams) middleware.Responder {
+func BuildListSubjectsHandler(db *sql.DB, schema string) func(subjects.ListSubjectsParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params subjects.ListSubjectsParams) middleware.Responder {
 
 		// Start a transaction for the request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			return listSubjectsInternalServerError(err.Error())
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			return listSubjectsInternalServerError(err.Error())

--- a/restapi/impl/subjects/update_subject.go
+++ b/restapi/impl/subjects/update_subject.go
@@ -13,7 +13,7 @@ import (
 )
 
 // BuildUpdateSubjectHandler builds the request handler for the update subject endpoint.
-func BuildUpdateSubjectHandler(db *sql.DB) func(subjects.UpdateSubjectParams) middleware.Responder {
+func BuildUpdateSubjectHandler(db *sql.DB, schema string) func(subjects.UpdateSubjectParams) middleware.Responder {
 
 	// Return the handler function.
 	return func(params subjects.UpdateSubjectParams) middleware.Responder {
@@ -22,6 +22,15 @@ func BuildUpdateSubjectHandler(db *sql.DB) func(subjects.UpdateSubjectParams) mi
 
 		// Start a transaction for this request.
 		tx, err := db.Begin()
+		if err != nil {
+			logger.Log.Error(err)
+			reason := err.Error()
+			return subjects.NewUpdateSubjectInternalServerError().WithPayload(
+				&models.ErrorOut{Reason: &reason},
+			)
+		}
+
+		_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 		if err != nil {
 			logger.Log.Error(err)
 			reason := err.Error()

--- a/restapi/impl/test/helpers_test.go
+++ b/restapi/impl/test/helpers_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/cyverse-de/permissions/models"
@@ -17,10 +18,15 @@ func addDefaultResourceType(tx *sql.Tx, name, description string, t *testing.T) 
 	}
 }
 
-func addDefaultResourceTypes(db *sql.DB, t *testing.T) {
+func addDefaultResourceTypes(db *sql.DB, schema string, t *testing.T) {
 
 	// Start a transaction.
 	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("unable to add default resource types: %s", err)
+	}
+
+	_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 	if err != nil {
 		t.Fatalf("unable to add default resource types: %s", err)
 	}
@@ -36,10 +42,15 @@ func addDefaultResourceTypes(db *sql.DB, t *testing.T) {
 	}
 }
 
-func addTestResource(db *sql.DB, name, resourceType string, t *testing.T) {
+func addTestResource(db *sql.DB, schema, name, resourceType string, t *testing.T) {
 
 	// Start a Transaction.
 	tx, err := db.Begin()
+	if err != nil {
+		t.Fatalf("unable to add a resource: %s", err)
+	}
+
+	_, err = tx.Exec(fmt.Sprintf("SET search_path TO %s", schema))
 	if err != nil {
 		t.Fatalf("unable to add a resource: %s", err)
 	}

--- a/restapi/impl/test/lookup_test.go
+++ b/restapi/impl/test/lookup_test.go
@@ -25,10 +25,10 @@ var groupMemberships = map[string][]*grouper.GroupInfo{
 
 var mockGrouperClient = grouper.NewMockGrouperClient(groupMemberships)
 
-func bySubjectAttempt(db *sql.DB, subjectType, subjectID string, lookup bool, minLevel *string) middleware.Responder {
+func bySubjectAttempt(db *sql.DB, schema, subjectType, subjectID string, lookup bool, minLevel *string) middleware.Responder {
 
 	// Build the request handler.
-	handler := impl.BuildBySubjectHandler(db, grouper.Grouper(mockGrouperClient))
+	handler := impl.BuildBySubjectHandler(db, grouper.Grouper(mockGrouperClient), schema)
 
 	// Attempt to look up the permissions.
 	params := permissions.BySubjectParams{
@@ -40,17 +40,17 @@ func bySubjectAttempt(db *sql.DB, subjectType, subjectID string, lookup bool, mi
 	return handler(params)
 }
 
-func bySubject(db *sql.DB, subjectType, subjectID string, lookup bool, minLevel *string) *models.PermissionList {
-	responder := bySubjectAttempt(db, subjectType, subjectID, lookup, minLevel)
+func bySubject(db *sql.DB, schema, subjectType, subjectID string, lookup bool, minLevel *string) *models.PermissionList {
+	responder := bySubjectAttempt(db, schema, subjectType, subjectID, lookup, minLevel)
 	return responder.(*permissions.BySubjectOK).Payload
 }
 
 func bySubjectAndResourceTypeAttempt(
-	db *sql.DB, subjectType, subjectID, resourceType string, lookup bool, minLevel *string,
+	db *sql.DB, schema, subjectType, subjectID, resourceType string, lookup bool, minLevel *string,
 ) middleware.Responder {
 
 	// Build the request handler.
-	handler := impl.BuildBySubjectAndResourceTypeHandler(db, grouper.Grouper(mockGrouperClient))
+	handler := impl.BuildBySubjectAndResourceTypeHandler(db, grouper.Grouper(mockGrouperClient), schema)
 
 	// Attempt to look up the permissions.
 	params := permissions.BySubjectAndResourceTypeParams{
@@ -64,18 +64,18 @@ func bySubjectAndResourceTypeAttempt(
 }
 
 func bySubjectAndResourceType(
-	db *sql.DB, subjectType, subjectID, resourceType string, lookup bool, minLevel *string,
+	db *sql.DB, schema, subjectType, subjectID, resourceType string, lookup bool, minLevel *string,
 ) *models.PermissionList {
-	responder := bySubjectAndResourceTypeAttempt(db, subjectType, subjectID, resourceType, lookup, minLevel)
+	responder := bySubjectAndResourceTypeAttempt(db, schema, subjectType, subjectID, resourceType, lookup, minLevel)
 	return responder.(*permissions.BySubjectAndResourceTypeOK).Payload
 }
 
 func bySubjectAndResourceAttempt(
-	db *sql.DB, subjectType, subjectID, resourceType, resourceName string, lookup bool, minLevel *string,
+	db *sql.DB, schema, subjectType, subjectID, resourceType, resourceName string, lookup bool, minLevel *string,
 ) middleware.Responder {
 
 	// Build the request handler.
-	handler := impl.BuildBySubjectAndResourceHandler(db, grouper.Grouper(mockGrouperClient))
+	handler := impl.BuildBySubjectAndResourceHandler(db, grouper.Grouper(mockGrouperClient), schema)
 
 	// Attempt to look up the permissions.
 	params := permissions.BySubjectAndResourceParams{
@@ -90,9 +90,9 @@ func bySubjectAndResourceAttempt(
 }
 
 func bySubjectAndResource(
-	db *sql.DB, subjectType, subjectID, resourceType, resourceName string, lookup bool, minLevel *string,
+	db *sql.DB, schema, subjectType, subjectID, resourceType, resourceName string, lookup bool, minLevel *string,
 ) *models.PermissionList {
-	responder := bySubjectAndResourceAttempt(db, subjectType, subjectID, resourceType, resourceName, lookup, minLevel)
+	responder := bySubjectAndResourceAttempt(db, schema, subjectType, subjectID, resourceType, resourceName, lookup, minLevel)
 	return responder.(*permissions.BySubjectAndResourceOK).Payload
 }
 
@@ -102,16 +102,16 @@ func TestBySubject(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "analysis", "r2", "read")
-	putPermission(db, "group", "g2id", "analysis", "r3", "read")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g2id", "analysis", "r3", "read")
 
 	// Look up the permissions and verify that we get the expected number of results.
-	perms := bySubject(db, "user", "s2", true, nil).Permissions
+	perms := bySubject(db, schema, "user", "s2", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -127,17 +127,17 @@ func TestBySubjectMultiplePermissions(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "app", "r1", "read")
-	putPermission(db, "user", "s2", "analysis", "r2", "read")
-	putPermission(db, "group", "g1id", "analysis", "r2", "write")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "r1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "write")
 
 	// Look up the permissions and verify that we get the expected number of results.
-	perms := bySubject(db, "user", "s2", true, nil).Permissions
+	perms := bySubject(db, schema, "user", "s2", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -153,17 +153,17 @@ func TestBySubjectIncorrectSubjectType(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "app", "r1", "read")
-	putPermission(db, "user", "s2", "analysis", "r2", "read")
-	putPermission(db, "group", "g1id", "analysis", "r2", "write")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "r1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "write")
 
 	// Attempt the lookup.
-	responder := bySubjectAttempt(db, "group", "s2", true, nil)
+	responder := bySubjectAttempt(db, schema, "group", "s2", true, nil)
 	errorOut := responder.(*permissions.BySubjectBadRequest).Payload
 	expected := "incorrect type for subject, s2: group"
 	if *errorOut.Reason != expected {
@@ -177,18 +177,18 @@ func TestBySubjectGroupsNotTransitive(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "app", "r1", "read")
-	putPermission(db, "user", "s2", "analysis", "r2", "read")
-	putPermission(db, "group", "g1id", "analysis", "r2", "write")
-	putPermission(db, "group", "g2id", "analysis", "r3", "own")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "r1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "r3", "own")
 
 	// Look up permissions and verify that we get the expected number of results.
-	perms := bySubject(db, "group", "g1id", true, nil).Permissions
+	perms := bySubject(db, schema, "group", "g1id", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -204,18 +204,18 @@ func TestBySubjectNonLookup(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "app", "r1", "read")
-	putPermission(db, "user", "s2", "analysis", "r2", "read")
-	putPermission(db, "group", "g1id", "analysis", "r2", "write")
-	putPermission(db, "group", "g2id", "analysis", "r3", "own")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "r1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "r3", "own")
 
 	// List permissions for s2 and verify that we get the expected results.
-	perms := bySubject(db, "user", "s2", false, nil).Permissions
+	perms := bySubject(db, schema, "user", "s2", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -225,7 +225,7 @@ func TestBySubjectNonLookup(t *testing.T) {
 	checkPerm(t, perms, 1, "r2", "s2", "read")
 
 	// List permissions for g1id and verify that we get the expected results.
-	perms = bySubject(db, "group", "g1id", false, nil).Permissions
+	perms = bySubject(db, schema, "group", "g1id", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -241,22 +241,22 @@ func TestBySubjectMinLevel(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "r1", "own")
-	putPermission(db, "group", "g1id", "app", "r1", "read")
-	putPermission(db, "user", "s2", "analysis", "r2", "read")
-	putPermission(db, "group", "g1id", "analysis", "r2", "write")
-	putPermission(db, "group", "g2id", "analysis", "r3", "own")
-	putPermission(db, "user", "s2", "app", "r4", "read")
+	putPermission(db, schema, "user", "s2", "app", "r1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "r1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "r2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "r2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "r3", "own")
+	putPermission(db, schema, "user", "s2", "app", "r4", "read")
 
 	// The minimum level for this search.
 	minLevel := "write"
 
 	// List permissions for s2 and verify that we get the expected number of results.
-	perms := bySubject(db, "user", "s2", true, &minLevel).Permissions
+	perms := bySubject(db, schema, "user", "s2", true, &minLevel).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -272,23 +272,23 @@ func TestBySubjectAndResourceType(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
-	putPermission(db, "user", "s2", "analysis", "analysis1", "own")
-	putPermission(db, "group", "g1id", "analysis", "analysis1", "read")
-	putPermission(db, "user", "s2", "analysis", "analysis2", "read")
-	putPermission(db, "group", "g1id", "analysis", "analysis2", "write")
-	putPermission(db, "group", "g2id", "analysis", "analysis3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis1", "own")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "analysis3", "own")
 
 	// Look up app permissions and verify that we get the expected number of results.
-	perms := bySubjectAndResourceType(db, "user", "s2", "app", true, nil).Permissions
+	perms := bySubjectAndResourceType(db, schema, "user", "s2", "app", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -298,7 +298,7 @@ func TestBySubjectAndResourceType(t *testing.T) {
 	checkPerm(t, perms, 1, "app2", "g1id", "write")
 
 	// Look up analysis permissions and verify that we get the expected number of results.
-	perms = bySubjectAndResourceType(db, "user", "s2", "analysis", true, nil).Permissions
+	perms = bySubjectAndResourceType(db, schema, "user", "s2", "analysis", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -314,18 +314,18 @@ func TestBySubjectAndResourceTypeIncorrectSubjectType(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// Look up permissions and verify that we get the expected number of results.
-	responder := bySubjectAndResourceTypeAttempt(db, "group", "s2", "app", true, nil)
+	responder := bySubjectAndResourceTypeAttempt(db, schema, "group", "s2", "app", true, nil)
 	errorOut := responder.(*permissions.BySubjectAndResourceTypeBadRequest).Payload
 	expected := "incorrect type for subject, s2: group"
 	if *errorOut.Reason != expected {
@@ -339,18 +339,18 @@ func TestBySubjectAndResourceTypeUnknownResourceType(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// Look up permissions and verify that we get the expected number of results.
-	perms := bySubjectAndResourceType(db, "user", "s2", "blargle", true, nil).Permissions
+	perms := bySubjectAndResourceType(db, schema, "user", "s2", "blargle", true, nil).Permissions
 	if len(perms) != 0 {
 		t.Errorf("unexpected number of results: %d", len(perms))
 	}
@@ -362,18 +362,18 @@ func TestBySubjectAndResourceTypeGroupsNotTransitive(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// Look up permissions and verify that we get the expected number of results.
-	perms := bySubjectAndResourceType(db, "group", "g1id", "app", true, nil).Permissions
+	perms := bySubjectAndResourceType(db, schema, "group", "g1id", "app", true, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -389,23 +389,23 @@ func TestBySubjectAndResourceTypeNonLookup(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
-	putPermission(db, "user", "s2", "analysis", "analysis1", "own")
-	putPermission(db, "group", "g1id", "analysis", "analysis1", "read")
-	putPermission(db, "user", "s2", "analysis", "analysis2", "read")
-	putPermission(db, "group", "g1id", "analysis", "analysis2", "write")
-	putPermission(db, "group", "g2id", "analysis", "analysis3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis1", "own")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "analysis3", "own")
 
 	// Look up the app permissions for s2 and verify that we get the expected number of results.
-	perms := bySubjectAndResourceType(db, "user", "s2", "app", false, nil).Permissions
+	perms := bySubjectAndResourceType(db, schema, "user", "s2", "app", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -415,7 +415,7 @@ func TestBySubjectAndResourceTypeNonLookup(t *testing.T) {
 	checkPerm(t, perms, 1, "app2", "s2", "read")
 
 	// Look up the app permissions for g1id and verify that we get the expected number of results.
-	perms = bySubjectAndResourceType(db, "group", "g1id", "app", false, nil).Permissions
+	perms = bySubjectAndResourceType(db, schema, "group", "g1id", "app", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -425,7 +425,7 @@ func TestBySubjectAndResourceTypeNonLookup(t *testing.T) {
 	checkPerm(t, perms, 1, "app2", "g1id", "write")
 
 	// Look up the analysis permissions for s2 and verify that we got the expected number of results.
-	perms = bySubjectAndResourceType(db, "user", "s2", "analysis", false, nil).Permissions
+	perms = bySubjectAndResourceType(db, schema, "user", "s2", "analysis", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -435,7 +435,7 @@ func TestBySubjectAndResourceTypeNonLookup(t *testing.T) {
 	checkPerm(t, perms, 1, "analysis2", "s2", "read")
 
 	// Look up the analysis permissions for g1id and verify that we get the expected number of results.
-	perms = bySubjectAndResourceType(db, "group", "g1id", "analysis", false, nil).Permissions
+	perms = bySubjectAndResourceType(db, schema, "group", "g1id", "analysis", false, nil).Permissions
 	if len(perms) != 2 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -451,26 +451,26 @@ func TestBySubjectAndResourceTypeMinLevel(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
-	putPermission(db, "user", "s2", "analysis", "analysis1", "own")
-	putPermission(db, "group", "g1id", "analysis", "analysis1", "read")
-	putPermission(db, "user", "s2", "analysis", "analysis2", "read")
-	putPermission(db, "group", "g1id", "analysis", "analysis2", "write")
-	putPermission(db, "group", "g2id", "analysis", "analysis3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis1", "own")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis1", "read")
+	putPermission(db, schema, "user", "s2", "analysis", "analysis2", "read")
+	putPermission(db, schema, "group", "g1id", "analysis", "analysis2", "write")
+	putPermission(db, schema, "group", "g2id", "analysis", "analysis3", "own")
 
 	// The minimum level for the search.
 	minLevel := "own"
 
 	// Look up app permissions and verify that we get the expected number of results.
-	perms := bySubjectAndResourceType(db, "user", "s2", "app", true, &minLevel).Permissions
+	perms := bySubjectAndResourceType(db, schema, "user", "s2", "app", true, &minLevel).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -479,7 +479,7 @@ func TestBySubjectAndResourceTypeMinLevel(t *testing.T) {
 	checkPerm(t, perms, 0, "app1", "s2", "own")
 
 	// Look up analysis permissions and verify that we get the expected number of results.
-	perms = bySubjectAndResourceType(db, "user", "s2", "analysis", true, &minLevel).Permissions
+	perms = bySubjectAndResourceType(db, schema, "user", "s2", "analysis", true, &minLevel).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -494,18 +494,18 @@ func TestBySubjectAndResource(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// Look up permissions for app1 and verify that we get the expected number of results.
-	perms := bySubjectAndResource(db, "user", "s2", "app", "app1", true, nil).Permissions
+	perms := bySubjectAndResource(db, schema, "user", "s2", "app", "app1", true, nil).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -514,7 +514,7 @@ func TestBySubjectAndResource(t *testing.T) {
 	checkPerm(t, perms, 0, "app1", "s2", "own")
 
 	// Look up permissions for app2 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app2", true, nil).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app2", true, nil).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -523,7 +523,7 @@ func TestBySubjectAndResource(t *testing.T) {
 	checkPerm(t, perms, 0, "app2", "g1id", "write")
 
 	// Look up permissions for app3 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app3", true, nil).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app3", true, nil).Permissions
 	if len(perms) != 0 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -535,18 +535,18 @@ func TestBySubjectAndResourceNonLookup(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// Look up permissions for app1 and verify that we get the expected number of results.
-	perms := bySubjectAndResource(db, "user", "s2", "app", "app1", false, nil).Permissions
+	perms := bySubjectAndResource(db, schema, "user", "s2", "app", "app1", false, nil).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -555,7 +555,7 @@ func TestBySubjectAndResourceNonLookup(t *testing.T) {
 	checkPerm(t, perms, 0, "app1", "s2", "own")
 
 	// Look up permissions for app2 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app2", false, nil).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app2", false, nil).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -564,7 +564,7 @@ func TestBySubjectAndResourceNonLookup(t *testing.T) {
 	checkPerm(t, perms, 0, "app2", "s2", "read")
 
 	// Look up permissions for app3 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app3", true, nil).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app3", true, nil).Permissions
 	if len(perms) != 0 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -576,21 +576,21 @@ func TestBySubjectAndResourceMinLevel(t *testing.T) {
 	}
 
 	// Initialize the database.
-	db := initdb(t)
-	addDefaultResourceTypes(db, t)
+	db, schema := initdb(t)
+	addDefaultResourceTypes(db, schema, t)
 
 	// Add some permissions.
-	putPermission(db, "user", "s2", "app", "app1", "own")
-	putPermission(db, "group", "g1id", "app", "app1", "read")
-	putPermission(db, "user", "s2", "app", "app2", "read")
-	putPermission(db, "group", "g1id", "app", "app2", "write")
-	putPermission(db, "group", "g2id", "app", "app3", "own")
+	putPermission(db, schema, "user", "s2", "app", "app1", "own")
+	putPermission(db, schema, "group", "g1id", "app", "app1", "read")
+	putPermission(db, schema, "user", "s2", "app", "app2", "read")
+	putPermission(db, schema, "group", "g1id", "app", "app2", "write")
+	putPermission(db, schema, "group", "g2id", "app", "app3", "own")
 
 	// The  minimum level for the search.
 	minLevel := "own"
 
 	// Look up permissions for app1 and verify that we get the expected number of results.
-	perms := bySubjectAndResource(db, "user", "s2", "app", "app1", true, &minLevel).Permissions
+	perms := bySubjectAndResource(db, schema, "user", "s2", "app", "app1", true, &minLevel).Permissions
 	if len(perms) != 1 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
@@ -599,13 +599,13 @@ func TestBySubjectAndResourceMinLevel(t *testing.T) {
 	checkPerm(t, perms, 0, "app1", "s2", "own")
 
 	// Look up permissions for app2 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app2", true, &minLevel).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app2", true, &minLevel).Permissions
 	if len(perms) != 0 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}
 
 	// Look up permissions for app3 and verify that we get the expected number of results.
-	perms = bySubjectAndResource(db, "user", "s2", "app", "app3", true, nil).Permissions
+	perms = bySubjectAndResource(db, schema, "user", "s2", "app", "app3", true, nil).Permissions
 	if len(perms) != 0 {
 		t.Fatalf("unexpected number of results: %d", len(perms))
 	}


### PR DESCRIPTION
This is a little verbose, but I think it's clean enough. I just copied the various error strategies from the code surrounding any given instance.