### PR TITLE
CORE-1874: fix unit tests

### DIFF
--- a/clients/grouper/mock.go
+++ b/clients/grouper/mock.go
@@ -1,6 +1,8 @@
 package grouper
 
 import (
+	"context"
+
 	"github.com/cyverse-de/permissions/models"
 )
 
@@ -15,16 +17,16 @@ func NewMockGrouperClient(groups map[string][]*GroupInfo) *MockGrouperClient {
 }
 
 // GroupsForSubject returns a mock list of groups for a subject.
-func (gc *MockGrouperClient) GroupsForSubject(subjectID string) ([]*GroupInfo, error) {
+func (gc *MockGrouperClient) GroupsForSubject(_ context.Context, subjectID string) ([]*GroupInfo, error) {
 	return gc.groups[subjectID], nil
 }
 
 // AddSourceIDToPermissions is a no-op for now.
-func (gc *MockGrouperClient) AddSourceIDToPermissions(_ []*models.Permission) error {
+func (gc *MockGrouperClient) AddSourceIDToPermissions(_ context.Context, _ []*models.Permission) error {
 	return nil
 }
 
 // AddSourceIDToPermission is a no-op for now.
-func (gc *MockGrouperClient) AddSourceIDToPermission(_ *models.Permission) error {
+func (gc *MockGrouperClient) AddSourceIDToPermission(_ context.Context, _ *models.Permission) error {
 	return nil
 }

--- a/restapi/impl/test/helpers_test.go
+++ b/restapi/impl/test/helpers_test.go
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -13,7 +14,7 @@ import (
 
 func addDefaultResourceType(tx *sql.Tx, name, description string, t *testing.T) {
 	rt := &models.ResourceTypeIn{Name: &name, Description: description}
-	if _, err := permsdb.AddNewResourceType(tx, rt); err != nil {
+	if _, err := permsdb.AddNewResourceType(context.Background(), tx, rt); err != nil {
 		tx.Rollback()
 		t.Fatalf("unable to add default resource types: %s", err)
 	}
@@ -57,7 +58,7 @@ func addTestResource(db *sql.DB, schema, name, resourceType string, t *testing.T
 	}
 
 	// Get the resource type.
-	rt, err := permsdb.GetResourceTypeByName(tx, &resourceType)
+	rt, err := permsdb.GetResourceTypeByName(context.Background(), tx, &resourceType)
 	if err != nil {
 		tx.Rollback()
 		t.Fatalf("unable to add a resource: %s", err)
@@ -68,7 +69,7 @@ func addTestResource(db *sql.DB, schema, name, resourceType string, t *testing.T
 	}
 
 	// Insert the resource.
-	if _, err := permsdb.AddResource(tx, &name, rt.ID); err != nil {
+	if _, err := permsdb.AddResource(context.Background(), tx, &name, rt.ID); err != nil {
 		tx.Rollback()
 		t.Fatalf("unable to add a resource: %s", err)
 	}

--- a/restapi/impl/test/resources_test.go
+++ b/restapi/impl/test/resources_test.go
@@ -2,6 +2,7 @@
 package test
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -29,7 +30,7 @@ func listResourcesDirectly(db *sql.DB, schema string, t *testing.T) []*models.Re
 	}
 
 	// List the resources.
-	resources, err := permsdb.ListResources(tx, nil, nil)
+	resources, err := permsdb.ListResources(context.Background(), tx, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to list resources: %s", err)
 	}


### PR DESCRIPTION
The unit tests succeed with these changes in place:

```
$ go test ./...
?   	github.com/cyverse-de/permissions/clients/grouper	[no test files]
?   	github.com/cyverse-de/permissions/cmd/permissions-server	[no test files]
?   	github.com/cyverse-de/permissions/conversions/app-registration	[no test files]
?   	github.com/cyverse-de/permissions/conversions/tool-registration	[no test files]
?   	github.com/cyverse-de/permissions/logger	[no test files]
?   	github.com/cyverse-de/permissions/models	[no test files]
?   	github.com/cyverse-de/permissions/restapi	[no test files]
ok  	github.com/cyverse-de/permissions/restapi/impl/db	1.029s
?   	github.com/cyverse-de/permissions/restapi/impl/permissions	[no test files]
?   	github.com/cyverse-de/permissions/restapi/impl/resources	[no test files]
?   	github.com/cyverse-de/permissions/restapi/impl/resourcetypes	[no test files]
?   	github.com/cyverse-de/permissions/restapi/impl/status	[no test files]
?   	github.com/cyverse-de/permissions/restapi/impl/subjects	[no test files]
ok  	github.com/cyverse-de/permissions/restapi/impl/test	1.093s
?   	github.com/cyverse-de/permissions/restapi/operations	[no test files]
?   	github.com/cyverse-de/permissions/restapi/operations/permissions	[no test files]
?   	github.com/cyverse-de/permissions/restapi/operations/resource_types	[no test files]
?   	github.com/cyverse-de/permissions/restapi/operations/resources	[no test files]
?   	github.com/cyverse-de/permissions/restapi/operations/status	[no test files]
?   	github.com/cyverse-de/permissions/restapi/operations/subjects	[no test files]
```
