### PR TITLE
CORE-2040: support nested groups

### DIFF
--- a/clients/grouper/grouper.go
+++ b/clients/grouper/grouper.go
@@ -27,7 +27,7 @@ type Grouper interface {
 	GroupsForSubject(context.Context, string) ([]*GroupInfo, error)
 	AddSourceIDToPermissions(context.Context, []*models.Permission) error
 	AddSourceIDToPermission(context.Context, *models.Permission) error
-	ListGroupMembers(context.Context, models.ExternalSubjectID) ([]*models.SubjectOut, error)
+	ListUsersInGroup(context.Context, models.ExternalSubjectID) ([]*models.SubjectOut, error)
 }
 
 // Client represents a Grouper client instance.
@@ -132,18 +132,19 @@ func (gc *Client) AddSourceIDToPermission(ctx context.Context, permission *model
 	return gc.AddSourceIDToPermissions(ctx, []*models.Permission{permission})
 }
 
-// ListGroupMembers returns the list of subjects in the group with the given ID.
-func (gc *Client) ListGroupMembers(
+// ListUsersInGroup returns the list of users in the group with the given ID. Nested groups are supported, but only the
+// users in the group or any nested groups are returned.
+func (gc *Client) ListUsersInGroup(
 	ctx context.Context,
 	groupID models.ExternalSubjectID,
 ) ([]*models.SubjectOut, error) {
-	ctx, span := otel.Tracer(otelName).Start(ctx, "ListGroupMembers")
+	ctx, span := otel.Tracer(otelName).Start(ctx, "ListUsersInGroup")
 	defer span.End()
 
 	// Query the database.
 	query := `SELECT subject_id, subject_source FROM grouper_memberships_v
-            WHERE group_id = $1 AND list_name = 'members'`
-	rows, err := gc.db.QueryContext(ctx, query, string(groupID))
+            WHERE group_id = $1 AND list_name = 'members' AND subject_source != $2`
+	rows, err := gc.db.QueryContext(ctx, query, string(groupID), string(groupSubjectSource))
 	if err != nil {
 		return nil, err
 	}

--- a/clients/grouper/mock.go
+++ b/clients/grouper/mock.go
@@ -67,8 +67,9 @@ func (gc *MockGrouperClient) AddSourceIDToPermission(_ context.Context, _ *model
 	return nil
 }
 
-// ListGroupMembers obtains a list of group members from the memberships field in the mock Grouper client.
-func (gc *MockGrouperClient) ListGroupMembers(
+// ListUsersInGroup obtains a list of group members from the memberships field in the mock Grouper client. No attempts
+// are made to mock nested groups at this time.
+func (gc *MockGrouperClient) ListUsersInGroup(
 	_ context.Context,
 	subjectID models.ExternalSubjectID,
 ) ([]*models.SubjectOut, error) {

--- a/restapi/impl/permissions/list_resource_permissions.go
+++ b/restapi/impl/permissions/list_resource_permissions.go
@@ -55,23 +55,12 @@ func expandGroupPermissions(
 	// Get the list of members for each of the groups.
 	membersOf := make(map[models.ExternalSubjectID][]*models.SubjectOut, len(groupIDs))
 	for _, groupID := range groupIDs {
-		members, err := grouperClient.ListGroupMembers(ctx, groupID)
+		members, err := grouperClient.ListUsersInGroup(ctx, groupID)
 		if err != nil {
 			logger.Log.Errorf("listing members of group %s: %v", groupID, err)
 			return nil, err
 		}
 		membersOf[groupID] = members
-
-		// Run a quick sanity check to make sure that recursive group membership isn't being used.
-		for _, member := range members {
-			if grouperClient.IsGroupSource(*member.SubjectSourceID) {
-				return nil, fmt.Errorf(
-					"recursive groups not supported - group %s contains group %s",
-					string(groupID),
-					string(*member.SubjectID),
-				)
-			}
-		}
 	}
 
 	// Create some maps for deduplication and caching.


### PR DESCRIPTION
I was exploring the Grouper database schema today, and I realized that we can support nested groups. This change updates a query to remove groups from the result set when trying to obtain a list of users in a group (users in nested groups are included automatically) and removes the check to verify that no groups are in the list of group members.